### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -44,7 +44,7 @@ Get involved and be a part of our mission to enhance application security:
 
 ## Unveiling the Cyber Odyssey
 
-The Open Web Application Security Project (OWASP) is a nonprofit foundation committed to enhancing software security. Our projects, tools, documents, forums, and chapters are open to all who share an interest in advancing application security.
+The Open Worldwide Application Security Project (OWASP) is a nonprofit foundation committed to enhancing software security. Our projects, tools, documents, forums, and chapters are open to all who share an interest in advancing application security.
 
 Dive into OWASP's world:
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)